### PR TITLE
Fix docstring issues

### DIFF
--- a/dryable/__init__.py
+++ b/dryable/__init__.py
@@ -1,5 +1,6 @@
-import logging
 import collections
+from functools import wraps
+import logging
 
 class Dryable:
     _dryRun = collections.defaultdict( lambda: False )
@@ -17,6 +18,7 @@ class Dryable:
             cls._dryRun[ label ] = False
 
     def __call__( self, function ):
+        @wraps(function)
         def _decorated( * args, ** kwargs ):
             if self._dryRun[ self._label ]:
                 argsString = ', '.join( [ str( argument ) for argument in args ] )
@@ -28,8 +30,6 @@ class Dryable:
                 return self._value
             return function( * args, ** kwargs )
 
-        _decorated.__doc__ = function.__doc__
-        _decorated.__name__ = function.__name__
         return _decorated
 
 set = Dryable.set


### PR DESCRIPTION
Functions decorated with dryable are losing their docstrings. This is
problematic when using them to generate the documentation with Sphinx
for instance.

Fixes haarcuba/dryable#2