### PR TITLE
Add ability to declare decorator in logging_msg parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,30 @@ functionB() # this will run for real
 ### Logging
 
 Dryable logs to a logger called `dryable` which is available via `Dryable.logger`
+
+#### What If I want to log a dryable function with a custom message ?
+
+You can define a custom message using ` logging_msg` parameter:
+```
+import dryable
+
+@dryable.Dryable( logging_msg = 'Function A were not executed (--dry-run)' )
+def functionA():
+    print( "Hi, I am A" )
+```
+
+Alternatively you can also inject some decorators:
+
+| Placeholder      	| Description                 	      |
+|------------------	|-------------------------------------|
+| {label}          	| Label defined in @Dryable()         |
+| {function}       	| Function name               	      |
+| {args}, {kwargs} 	| Args passed to the function 	      |
+
+```
+import dryable
+
+@dryable.Dryable( logging_msg = 'Would have called {function} with args {args} (--dry-run)' )
+def functionA(paramA):
+    print( "Hi, I am A" )
+```

--- a/dryable/__init__.py
+++ b/dryable/__init__.py
@@ -27,7 +27,8 @@ class Dryable:
                 if len( kwargs ) > 0:
                     if len( args ) > 0:
                         kwargsString = ', {}'.format( kwargsString )
-                logging_msg = self._logging_msg or 'dryable[{label}] skip: {function}( {args}{kwargs} )'.format(
+                logging_msg = self._logging_msg or 'dryable[{label}] skip: {function}( {args}{kwargs} )'
+                logging_msg.format(
                     label = self._label, function = function.__qualname__, args = argsString, kwargs = kwargsString )
                 Dryable.logger.info(logging_msg)
                 return self._value


### PR DESCRIPTION
# Improvement 
* Add ability to declare decorator in `logging_msg` parameter
  That way we can reuse them and have more valuable custom log messages.

# Misc
* Update README.md to include the notion of `logging_msg`
  That way we are aware of this feature without reading the code source (I discovered it by accident :) ) 